### PR TITLE
切换异常解决

### DIFF
--- a/plugin/smartim.vim
+++ b/plugin/smartim.vim
@@ -5,7 +5,9 @@ endif
 let s:imselect_path = expand('<sfile>:p:h') . "/im-select "
 
 function! SmartIM_SelectDefault()
-    let b:saved_im = system(s:imselect_path)
+    if !exists("b:saved_im") || b:saved_im == g:smartim_default
+        let b:saved_im = system(s:imselect_path)
+    endif
     if v:shell_error
         unlet b:saved_im
     else


### PR DESCRIPTION
mac下使用squirrel输入法，vim使用spf13配置的多个插件，出现普通模式切换回插入模式时输入法状态没恢复问题。测试发现插入模式切换到普通模式时调用SmartIM_SelectDefault()多次，使b:saved_im变量被置回默认值，导致出现该问题。由于未能找到问题源头，故在函数内添加条件，避免多次修改该变量。
